### PR TITLE
Relax version constraints for modules

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,15 +4,15 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4, < 5"
+      version = ">= 4"
     }
     http = {
       source  = "hashicorp/http"
-      version = ">= 3, < 4"
+      version = ">= 3"
     }
     tls = {
       source  = "hashicorp/tls"
-      version = ">= 4, < 5"
+      version = ">= 4"
     }
   }
 }


### PR DESCRIPTION
Remove upper boundary as version upgrades need to be tested when applying the root modules anyway.