### PR TITLE
Add support for resource-specific tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,5 @@ module "iam-openid-connect-provider" {
 
   url            = "https://token.actions.githubusercontent.com"
   client_id_list = ["sts.amazonaws.com"]
-
-  tags = {
-    app = "example"
-    env = "production"
-  }
 }
 ```

--- a/_test/main.tf
+++ b/_test/main.tf
@@ -8,7 +8,7 @@ module "iam-openid-connect-provider" {
   url            = "https://token.actions.githubusercontent.com"
   client_id_list = ["sts.amazonaws.com"]
 
-  tags = {
+  default_tags = {
     app = "example"
     env = "production"
   }

--- a/main.tf
+++ b/main.tf
@@ -24,5 +24,5 @@ resource "aws_iam_openid_connect_provider" "this" {
     ).sha1_fingerprint,
   ]
 
-  tags = var.tags
+  tags = merge(var.default_tags, var.iam_openid_connect_provider_tags)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,15 +1,33 @@
 variable "client_id_list" {
-  type        = list(string)
-  description = "List of client IDs, also known as audiences"
+  type = list(string)
+
+  description = <<EOS
+List of client IDs, also known as audiences.
+EOS
 }
 
-variable "tags" {
-  type        = map(string)
-  default     = {}
-  description = "Tags to be attached to the IAM OpenID Connect provider"
+variable "default_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to all AWS resources created by this module.
+EOS
+}
+
+variable "iam_openid_connect_provider_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the IAM OpenID Connect Provider.
+EOS
 }
 
 variable "url" {
-  type        = string
-  description = "URL of the OpenID provider"
+  type = string
+
+  description = <<EOS
+URL of the OpenID provider.
+EOS
 }


### PR DESCRIPTION
Breaking change: Renaming `var.tags` to `var.default_tag` in order to make it clearer that those are tags are applied to all AWS resources.