### PR TITLE
Breaking change: Rename `var.tags` to `var.default_tags`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,5 @@ module "iam-openid-connect-provider" {
 
   url            = "https://token.actions.githubusercontent.com"
   client_id_list = ["sts.amazonaws.com"]
-
-  tags = {
-    app = "example"
-    env = "production"
-  }
 }
 ```

--- a/_test/main.tf
+++ b/_test/main.tf
@@ -8,7 +8,7 @@ module "iam-openid-connect-provider" {
   url            = "https://token.actions.githubusercontent.com"
   client_id_list = ["sts.amazonaws.com"]
 
-  tags = {
+  default_tags = {
     app = "example"
     env = "production"
   }

--- a/main.tf
+++ b/main.tf
@@ -24,5 +24,5 @@ resource "aws_iam_openid_connect_provider" "this" {
     ).sha1_fingerprint,
   ]
 
-  tags = var.tags
+  tags = var.default_tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -6,7 +6,7 @@ List of client IDs, also known as audiences.
 EOS
 }
 
-variable "tags" {
+variable "default_tags" {
   type    = map(string)
   default = {}
 


### PR DESCRIPTION
This change is done to make it more clear, that tags specified via this attribute will be assigned to all AWS resources created by this module.

Also drop this attribute from the usage example in the `README.md`, as this attribute is rather for edge cases, as default tags typically specified via the `default_tags` block of the AWS provider.